### PR TITLE
changed uberfire-bom version to KIE version

### DIFF
--- a/ba-platform-bom/pom.xml
+++ b/ba-platform-bom/pom.xml
@@ -73,7 +73,7 @@
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-bom</artifactId>
         <type>pom</type>
-        <version>${version.org.uberfire}</version>
+        <version>${version.org.kie}</version>
         <scope>import</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
The commit https://github.com/kiegroup/droolsjbpm-build-bootstrap/commit/34dfe2ec1c3634a0d06db0b16f49b57e5e085301 moved uberfire-bom from appformer into droolsjbpm-build-bootstrap, with uberfire-bom version kept as Appformer version. Since this is not very user-friendly and breaks product build, this PR proposes a change of uberfire-bom version to KIE version to align it with the rest of the BOMs.